### PR TITLE
ci: don't run tests when markdown files are changed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - "!**.md"
+  pull_request:
+    paths:
+      - "!**.md"
+  workflow_dispatch:
 
 jobs:
   all_tests:


### PR DESCRIPTION
To prevent the tests workflow from running unnecessarily we don't run it when Markdown files are changed